### PR TITLE
Fix book pagination after resize

### DIFF
--- a/assets/js/book-pagination.js
+++ b/assets/js/book-pagination.js
@@ -337,9 +337,17 @@ class BookPagination {
       this.isMobile = window.innerWidth <= 768;
       
       if (wasMobile !== this.isMobile) {
-        // Adjust current page for layout change
-        if (this.isMobile && this.currentPage % 2 === 1) {
-          this.currentPage--;
+        // Ensure current page index works for the new layout
+        if (this.isMobile) {
+          // Mobile view shows one page at a time
+          if (this.currentPage % 2 === 1) {
+            this.currentPage--;
+          }
+        } else {
+          // Desktop view uses two-page spreads; start on an even index
+          if (this.currentPage % 2 === 1) {
+            this.currentPage--;
+          }
         }
         this.generatePages();
         this.updateDisplay();


### PR DESCRIPTION
## Summary
- fix book pagination `setupEventListeners` to reset current page when switching between single page and two-page view

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68815a4954808327ad35510689fc9e56